### PR TITLE
Update showmode in ~/.config/nvim/config/options.lua

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -43,7 +43,7 @@ opt.modifiable = true
 opt.guicursor =
 	"n-v-c:block,i-ci-ve:block,r-cr:hor20,o:hor50,a:blinkwait700-blinkoff400-blinkon250-Cursor/lCursor,sm:block-blinkwait175-blinkoff150-blinkon175"
 opt.encoding = "UTF-8"
-opt.showmode = false
+opt.showmode = true
 
 -- folds
 opt.foldmethod = "expr"


### PR DESCRIPTION
I have modified opt.showmode to true. Previously, when it was set to false, I had to manually enter :set showmode just to check if I was in insert or visual mode.





