### PR TITLE
Ensure to pull from the master branch of nvim-treesitter

### DIFF
--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -7,6 +7,7 @@
 
 return {
 	"nvim-treesitter/nvim-treesitter",
+	branch = 'master',
 	build = ":TSUpdate",
 	event = { "BufReadPost", "BufNewFile" },
 	lazy = false,


### PR DESCRIPTION
The main/default branch of nvim-treesitter has some breaking API changes. So, it was necessary to ensure to pull from the master branch.